### PR TITLE
Expose more tools in the default package

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,9 +102,9 @@ Difference between `airss` and `airss-with-default-names`
 =========================================================
 
 The AIRSS package is consisted of many small binaries and scripts.
-Installing all of them in `bin` folder of the environment may not be ideal, and it is like to cause conflicts with other packages. 
+Installing all of them in `bin` folder of the environment may not be ideal and is likely to cause conflicts with other packages. 
 
-Hence, by default, only the following tools are exposed:
+Hence, in the default package `airss`, only the following tools are exposed:
 ```
 airss.pl
 buildcell
@@ -117,9 +117,9 @@ respack
 resplit
 ```
 
-Nevertheless, all of the executables can be accessed with the `airss` executable acting as the main entry point.
+Nevertheless, all of the executables can still be accessed with the `airss` executable acting as the main entry point.
 
-For example,  `airss castep_relax` runs the `castep_relax` script this is not directly exposed.
+For example,  `airss castep_relax` runs the `castep_relax` script.
 
 On the other hand, the `airss-with-default-names` installs all tools in the environment.
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,30 @@ mamba repoquery whoneeds airss --channel conda-forge
 mamba repoquery depends airss --channel conda-forge
 ```
 
+Difference between `airss` and `airss-with-default-names`
+=========================================================
+
+The AIRSS package is consisted of many small binaries and scripts.
+Installing all of them in `bin` folder of the environment may not be ideal, and it is like to cause conflicts with other packages. 
+
+Hence, by default, only the following tools are exposed:
+```
+airss.pl
+buildcell
+cabal
+crud.pl
+cryan
+gencell
+rescat
+respack
+resplit
+```
+
+Nevertheless, all of the executables can be accessed with the `airss` executable acting as the main entry point.
+
+For example,  `airss castep_relax` runs the `castep_relax` script this is not directly exposed.
+
+On the other hand, the `airss-with-default-names` installs all tools in the environment.
 
 About conda-forge
 =================

--- a/recipe/airss-bin.txt
+++ b/recipe/airss-bin.txt
@@ -1,6 +1,6 @@
 airss.pl
 airss_version
-build_cell
+buildcell
 ca
 cabal
 castep2res

--- a/recipe/airss-tools.txt
+++ b/recipe/airss-tools.txt
@@ -1,0 +1,9 @@
+airss.pl
+buildcell
+cabal
+crud.pl
+cryan
+gencell
+rescat
+respack
+resplit

--- a/recipe/build_airss.sh
+++ b/recipe/build_airss.sh
@@ -32,7 +32,7 @@ for bin in $(cat ${RECIPE_DIR}/airss-tools.txt)
 do
   cat > ${PREFIX}/bin/${bin} <<EOF
 #!/usr/bin/env bash
-exec "${PREFIX}/libexec/airss/${bin}" "$@"
+exec "${PREFIX}/libexec/airss/${bin}" "\$@"
 EOF
   chmod +x ${PREFIX}/bin/${bin}
 done

--- a/recipe/build_airss.sh
+++ b/recipe/build_airss.sh
@@ -26,3 +26,13 @@ cp -v \
 mkdir -p "${PREFIX}/bin"
 sed "s;@PREFIX@;${PREFIX};g" "${RECIPE_DIR}/scripts/airss.sh" > "${PREFIX}/bin/airss"
 chmod +x "${PREFIX}/bin/airss"
+
+# Exposed limited set of the executables
+for bin in $(cat ${RECIPE_DIR}/airss-tools.txt)
+do
+  cat > ${PREFIX}/bin/${bin} <<EOF
+#!/usr/bin/env bash
+exec "${PREFIX}/libexec/airss/${bin}" "$@"
+EOF
+  chmod +x ${PREFIX}/bin/${bin}
+done

--- a/recipe/build_default.sh
+++ b/recipe/build_default.sh
@@ -5,7 +5,7 @@ for bin in $(cat ${RECIPE_DIR}/airss-bin.txt)
 do
   cat > ${PREFIX}/bin/${bin} <<EOF
 #!/usr/bin/env bash
-exec "${PREFIX}/libexec/airss/${bin}" "$@"
+exec "${PREFIX}/libexec/airss/${bin}" "\$@"
 EOF
   chmod +x ${PREFIX}/bin/${bin}
 done

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
     folder: external/spglib/spglib-1.16.5
 
 build:
-  number: 0
+  number: 1
   skip: true  # [not linux]
 
 outputs:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] ~~Reset the build number to `0` (if the version changed)~~
* [x] ~~[Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)~~
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Address #1 also fix an issue where `$@` is not escaped when creating wrapper scripts.
The default build now includes a few more commonly used tools. 
The README is updated to include difference between the default `airss` package and the `airss-with-default-names` package.